### PR TITLE
give student option to download audio

### DIFF
--- a/audio/static/html/audio.html
+++ b/audio/static/html/audio.html
@@ -1,7 +1,10 @@
 <div class="audio_block">
 <audio controls preload>
-  <source src="{src}">
-  <embed height="50" width="100" src="{src}">
+  <source src="{{ src }}">
+  <embed height="50" width="100" src="{{ src }}">
 </audio>
-
+{% if allow_download %}
+	<br />
+	<a href="{{ src }}" download>Download Audio</a>
+{% endif %}
 </div>

--- a/audio/static/html/audio_edit.html
+++ b/audio/static/html/audio_edit.html
@@ -3,7 +3,16 @@
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
         <label class="label setting-label" for="audio_src">Audio Source Location</label>
-        <input class="input setting-input" name="audio_src" id="audio_src" value="{src}" type="text" />
+        <input class="input setting-input" name="audio_src" id="audio_src" value="{{src}}" type="text" />
+      </div>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="allow_download">Allow Audio Download</label>
+        <select class="input setting-input allow_download" name="allow_download" id="allow_download">
+          <option value="True" {% if allow_download %} selected {% endif %}>True</option>
+          <option value="False" {% if not allow_download %} selected {% endif %}>False</option>
+        </select>
       </div>
     </li>
   </ul>

--- a/audio/static/js/src/audio_edit.js
+++ b/audio/static/js/src/audio_edit.js
@@ -2,7 +2,8 @@ function AudioEditBlock(runtime, element) {
   $(element).find('.save-button').bind('click', function() {
     var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
     var data = {
-      src: $(element).find('input[name=audio_src]').val()
+      src: $(element).find('input[name=audio_src]').val(),
+      allow_download: $(element).find('select[name=allow_download]').val()
     };
     $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
       window.location.reload(false);


### PR DESCRIPTION
Allows course authors to provide students with a download link to the audio file. 

In order to add the appropriate logic, I needed to render the HTML fragments as Django templates. This is done in the render_template method, which is based on:
https://github.com/edx-solutions/xblock-ooyala/blob/ac49b30452aff0cc34cace6a34b788e100490f24/ooyala_player/utils.py#L27

Studio:
![downloadstudio](https://cloud.githubusercontent.com/assets/410425/7162767/7b5a2694-e364-11e4-9ec2-b91d7a44ef84.png)

LMS:
![downloadlms](https://cloud.githubusercontent.com/assets/410425/7162772/7f9699c2-e364-11e4-96f3-4aa3807e7024.png)
